### PR TITLE
Add Argon2 password hashing module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ toolchain go1.24.11
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.8.0 // indirect
+	github.com/jackc/pgx/v5 v5.8.0
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
-	golang.org/x/crypto v0.46.0 // indirect
+	github.com/joho/godotenv v1.5.1
+	golang.org/x/crypto v0.46.0
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	argon2stuff "darkwave/passwordHandling"
 	"fmt"
 	"log"
 	"net"
@@ -766,7 +767,7 @@ func (s *Server) handleCommand(c *Client, cmd string) {
 			user.UserID = id
 
 			//hashing plain text password
-			password, err := HashPassword(passwordPlainText, param)
+			password, err := argon2stuff.HashPassword(passwordPlainText, (*argon2stuff.Argon2Params)(param))
 			if err != nil {
 				s.sendLine(c, "** error hashing password: %s", err)
 				return

--- a/passwordHandling/Argon2stuff.go
+++ b/passwordHandling/Argon2stuff.go
@@ -1,0 +1,135 @@
+package argon2stuff
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+)
+
+type Argon2Params struct {
+	Memory      uint32 //KiB
+	Iterations  uint32
+	Parallelism uint8
+	SaltLength  uint32
+	KeyLength   uint32
+}
+
+// var param = &Argon2Params{
+// 	Memory:      64 * 1024, // MiB
+// 	Iterations:  3,
+// 	Parallelism: 2,
+// 	SaltLength:  16,
+// 	KeyLength:   32,
+// }
+
+func HashPassword(password string, p *Argon2Params) (encodedHash string, err error) {
+	salt := make([]byte, p.SaltLength)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+
+	hash := argon2.IDKey([]byte(password), salt, p.Iterations, p.Memory, p.Parallelism, p.KeyLength)
+
+	b64Salt := base64.RawStdEncoding.EncodeToString(salt)
+	b64Hash := base64.RawStdEncoding.EncodeToString(hash)
+
+	encodedHash = fmt.Sprintf("$argon2id$v=19$m=%d,t=%d,p=%d$%s$%s", p.Memory, p.Iterations, p.Parallelism, b64Salt, b64Hash)
+	return encodedHash, nil
+}
+
+func VerifyPassword(password, encodedHash string) (bool, error) {
+	if password == "" {
+		return false, errors.New("empty password")
+	}
+	if strings.TrimSpace(encodedHash) == "" {
+		return false, errors.New("empty stored hash")
+	}
+
+	p, salt, expectedHash, err := DecodeHash(encodedHash)
+	if err != nil {
+		return false, err
+	}
+	if len(salt) < 8 {
+		return false, errors.New("bad salt")
+	}
+	if len(expectedHash) == 0 {
+		return false, errors.New("bad hash")
+	}
+
+	// Use the stored hash length as the key length to derive for verification
+	keyLen := uint32(len(expectedHash))
+	key := argon2.IDKey([]byte(password), salt, p.Iterations, p.Memory, p.Parallelism, keyLen)
+
+	if subtle.ConstantTimeCompare(key, expectedHash) == 1 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func DecodeHash(encodedHash string) (Argon2Params, []byte, []byte, error) {
+	// Expected: $argon2id$v=19$m=65536,t=3,p=2$<saltB64>$<hashB64>
+	parts := strings.Split(strings.TrimSpace(encodedHash), "$")
+	if len(parts) != 6 || parts[1] != "argon2id" {
+		return Argon2Params{}, nil, nil, errors.New("invalid encoded hash format")
+	}
+	if parts[2] != "v=19" {
+		return Argon2Params{}, nil, nil, errors.New("unsupported argon2 version")
+	}
+
+	// Parse m=...,t=...,p=...
+	var p Argon2Params
+	items := strings.Split(parts[3], ",")
+	if len(items) != 3 {
+		return Argon2Params{}, nil, nil, errors.New("invalid argon2 parameters")
+	}
+	var err error
+	p.Memory, err = parseUint32KV(items[0], "m")
+	if err != nil {
+		return Argon2Params{}, nil, nil, err
+	}
+	p.Iterations, err = parseUint32KV(items[1], "t")
+	if err != nil {
+		return Argon2Params{}, nil, nil, err
+	}
+	par, err := parseUint32KV(items[2], "p")
+	if err != nil {
+		return Argon2Params{}, nil, nil, err
+	}
+	if par > 255 {
+		return Argon2Params{}, nil, nil, errors.New("invalid parallelism value")
+	}
+	p.Parallelism = uint8(par)
+
+	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
+	if err != nil {
+		return Argon2Params{}, nil, nil, errors.New("invalid salt b64")
+	}
+
+	hash, err := base64.RawStdEncoding.DecodeString(parts[5])
+	if err != nil {
+		return Argon2Params{}, nil, nil, errors.New("invalid hash b64")
+	}
+
+	// Set key length from stored hash length
+	p.KeyLength = uint32(len(hash))
+
+	return p, salt, hash, nil
+}
+
+func parseUint32KV(s, key string) (uint32, error) {
+	kv := strings.SplitN(s, "=", 2)
+	if len(kv) != 2 || kv[0] != key {
+		return 0, errors.New("invalid format for " + key)
+	}
+	n, err := strconv.ParseUint(kv[1], 10, 32)
+	if err != nil {
+		return 0, err
+	}
+	return uint32(n), nil
+}


### PR DESCRIPTION
Introduced passwordHandling/Argon2stuff.go with functions for hashing and verifying passwords using Argon2id. Updated main.go to use the new module for password hashing, and adjusted go.mod to make dependencies direct where needed.