### PR TITLE
Refactor: split client main.go into focused files

### DIFF
--- a/cmd/client/config.go
+++ b/cmd/client/config.go
@@ -1,0 +1,3 @@
+package main
+
+const serverAddr = "localhost:3000"

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -1,28 +1,10 @@
 package main
 
 import (
-	"bufio"
 	"fmt"
 	"net"
 	"os"
-	"strings"
-	"time"
 )
-
-const serverAddr = "localhost:3000"
-
-func clearScreen() {
-	fmt.Print("\033[H\033[2J")
-}
-
-func moveCursorToBottom(rows int) {
-	fmt.Printf("\033[%d;0H", rows)
-}
-
-func printMessage(msg string) {
-	ts := time.Now().Format("15:04")
-	fmt.Printf("\r\033[K[%s] %s\n", ts, msg)
-}
 
 func main() {
 	conn, err := net.Dial("tcp", serverAddr)
@@ -36,54 +18,13 @@ func main() {
 	fmt.Println("=== connected to chat server ===")
 	fmt.Println()
 
-	// login
-	fmt.Print("nick: ")
-	reader := bufio.NewReader(os.Stdin)
-	nick, _ := reader.ReadString('\n')
-	nick = strings.TrimSpace(nick)
-
-	// send login command to server
+	nick, pass := promptLogin()
 	fmt.Fprintf(conn, "/nick %s\n", nick)
-
-	fmt.Print("password: ")
-	pass, _ := reader.ReadString('\n')
-	pass = strings.TrimSpace(pass)
-
 	fmt.Fprintf(conn, "%s\n", pass)
 
 	done := make(chan struct{})
-
-	// goroutine: read from server and print
-	go func() {
-		defer close(done)
-		s := bufio.NewScanner(conn)
-		for s.Scan() {
-			line := s.Text()
-			// clear current input line, print message, reprint prompt
-			fmt.Print("\r\033[K") // clear line
-			printMessage(line)
-			fmt.Print("> ") // reprint prompt
-		}
-		fmt.Println("\r\n** disconnected from server")
-	}()
-
-	// read from stdin and send to server
-	go func() {
-		scanner := bufio.NewScanner(os.Stdin)
-		fmt.Print("> ")
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-			if line == "" {
-				fmt.Print("> ")
-				continue
-			}
-			fmt.Fprintf(conn, "%s\n", line)
-			if line == "/quit" {
-				return
-			}
-			fmt.Print("> ")
-		}
-	}()
+	go readLoop(conn, done)
+	go writeLoop(conn)
 
 	<-done
 	fmt.Println("goodbye!")

--- a/cmd/client/net.go
+++ b/cmd/client/net.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+func readLoop(conn net.Conn, done chan struct{}) {
+	defer close(done)
+	s := bufio.NewScanner(conn)
+	for s.Scan() {
+		line := s.Text()
+		fmt.Print("\r\033[K")
+		printMessage(line) // from ui.go
+		fmt.Print("> ")
+	}
+	fmt.Println("\r\n** disconnected from server")
+}
+
+func writeLoop(conn net.Conn) {
+	scanner := bufio.NewScanner(os.Stdin)
+	fmt.Print("> ")
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			fmt.Print("> ")
+			continue
+		}
+		fmt.Fprintf(conn, "%s\n", line)
+		if line == "/quit" {
+			return
+		}
+		fmt.Print("> ")
+	}
+}

--- a/cmd/client/ui.go
+++ b/cmd/client/ui.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+func clearScreen() {
+	fmt.Print("\033[H\033[2J")
+}
+
+func moveCursorToBottom(rows int) {
+	fmt.Printf("\033[%d;0H", rows)
+}
+
+func printMessage(msg string) {
+	ts := time.Now().Format("15:04")
+	fmt.Printf("\r\033[K[%s] %s\n", ts, msg)
+}
+
+func promptLogin() (nick, pass string) {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Print("nick: ")
+	nick, _ = reader.ReadString('\n')
+	nick = strings.TrimSpace(nick)
+
+	fmt.Print("password: ")
+	pass, _ = reader.ReadString('\n')
+	pass = strings.TrimSpace(pass)
+
+	return nick, pass
+}


### PR DESCRIPTION
Split monolithic client main.go into separate files by responsibility:
- net.go: readLoop and writeLoop (TCP read/write goroutines)
- ui.go: clearScreen, moveCursorToBottom, printMessage, promptLogin
- config.go: serverAddr const
- main.go: entry point only, connects and wires everything together