### PR TITLE
Add AGC; dedupe and preserve voice channels

### DIFF
--- a/cmd/app/chat.go
+++ b/cmd/app/chat.go
@@ -316,6 +316,12 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 			currentDMKey = nil
 			members = []string{}
 			membersList.Refresh()
+			
+			// Clear all voice channels (we'll fetch new ones for current room only)
+			for i := range roomsWithVoice {
+				roomsWithVoice[i].voiceChannels = nil
+			}
+			
 			conn.send("/join " + r.name)
 			conn.send("/voicechannels")
 			conn.send("/rooms") // Refresh rooms list after joining
@@ -453,6 +459,12 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 					raw := strings.TrimPrefix(msg, "** rooms: ")
 					if raw != "(none)" {
 						allRooms := strings.Split(raw, ", ")
+						// Deduplicate rooms
+						seen := make(map[string]bool)
+						oldRooms := make(map[string][]string) // preserve existing voice channels
+						for _, r := range roomsWithVoice {
+							oldRooms[r.name] = r.voiceChannels
+						}
 						roomsWithVoice = []RoomWithVoice{}
 						for _, r := range allRooms {
 							// DMs are handled separately
@@ -461,7 +473,16 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 							}
 							// Remove leading # for storage (display logic adds it back)
 							displayName := strings.TrimPrefix(r, "#")
-							roomsWithVoice = append(roomsWithVoice, RoomWithVoice{name: displayName})
+							// Skip duplicates
+							if !seen[displayName] {
+								newRoom := RoomWithVoice{name: displayName}
+								// Preserve existing voice channels if the room already existed
+								if existingChannels, ok := oldRooms[displayName]; ok {
+									newRoom.voiceChannels = existingChannels
+								}
+								roomsWithVoice = append(roomsWithVoice, newRoom)
+								seen[displayName] = true
+							}
 						}
 						roomsList.Refresh()
 					}

--- a/cmd/app/voice.go
+++ b/cmd/app/voice.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -38,6 +39,10 @@ type VoiceClient struct {
 	outputStream  *portaudio.Stream                // current output stream (owned by playAudio)
 	outputGen     uint32                           // atomic; increment to tell playAudio to reopen output
 	micTracks     []*webrtc.TrackLocalStaticSample // active mic tracks for RestartAudio
+	
+	// AGC (Automatic Gain Control)
+	agcTargetLevel float32 // target RMS level (0.1 to 0.5 typically)
+	agcCurrentGain float32 // current gain multiplier
 }
 
 type SignalMsg struct {
@@ -56,8 +61,10 @@ func ListAudioDevices() ([]*portaudio.DeviceInfo, error) {
 
 func NewVoiceClient(myNick string) *VoiceClient {
 	return &VoiceClient{
-		myNick: myNick,
-		pc:     make(map[string]*webrtc.PeerConnection),
+		myNick:         myNick,
+		pc:             make(map[string]*webrtc.PeerConnection),
+		agcTargetLevel: 6500,  // target RMS - mid-range for better balance
+		agcCurrentGain: 1.0,   // start with unity gain
 	}
 }
 
@@ -516,6 +523,57 @@ func (vc *VoiceClient) handleICE(fromNick, payload string) {
 	}
 }
 
+// calculateRMS computes root mean square level of audio samples
+// For int16-scale float32 audio, returns values typically in 0-32768 range
+func calculateRMS(buf []float32) float32 {
+	if len(buf) == 0 {
+		return 0
+	}
+	var sum float32
+	for _, s := range buf {
+		sum += s * s
+	}
+	return float32(math.Sqrt(float64(sum / float32(len(buf)))))
+}
+
+// applyAGC normalizes audio gain to target RMS level
+// Works with int16-scale float32 audio (values typically 0-32768 range)
+// Applies exponential smoothing to prevent sudden level jumps
+// targetRMS: desired RMS level in int16 scale
+func (vc *VoiceClient) applyAGC(buf []float32, targetRMS float32) {
+	const smoothingFactor = 0.15
+	
+	rms := calculateRMS(buf)
+	
+	if rms < 100 { // silence threshold
+		return
+	}
+
+	// Calculate desired gain to reach target RMS
+	desiredGain := targetRMS / rms
+
+	// Clamp gain: allow 0.2x to 10.0x (wider range for more flexibility)
+	// This helps quiet speakers be heard and loud speakers not blast
+	if desiredGain > 10.0 {
+		desiredGain = 10.0  // up to +20dB for quiet audio
+	} else if desiredGain < 0.2 {
+		desiredGain = 0.2   // down to -14dB for loud audio
+	}
+
+	// Apply exponential smoothing
+	vc.agcCurrentGain = (1.0-smoothingFactor)*vc.agcCurrentGain + smoothingFactor*desiredGain
+
+	// Apply gain with clipping prevention
+	for i := range buf {
+		buf[i] *= vc.agcCurrentGain
+		if buf[i] > 32767 {
+			buf[i] = 32767
+		} else if buf[i] < -32768 {
+			buf[i] = -32768
+		}
+	}
+}
+
 func (vc *VoiceClient) captureMic(track *webrtc.TrackLocalStaticSample) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -601,12 +659,17 @@ func (vc *VoiceClient) captureMic(track *webrtc.TrackLocalStaticSample) {
 		// apply noise suppression
 		vad := denoiser.Process(floatBuf)
 
+		// apply automatic gain control (AGC) to normalize audio level
+		// This ensures consistent volume regardless of microphone sensitivity
+		vc.applyAGC(floatBuf, vc.agcTargetLevel)
+
 		// convert back float32 → int16
 		for i, f := range floatBuf {
 			buf[i] = int16(f)
 		}
 
-		isVoice := vad > 0.4
+		// VAD: more aggressive threshold (0.25) to filter out background noise
+		isVoice := vad > 0.25
 
 		if isVoice != lastSpeakingStatus && time.Since(lastStatusTime) > 200*time.Millisecond {
 			lastSpeakingStatus = isVoice

--- a/store.go
+++ b/store.go
@@ -268,7 +268,7 @@ func (r *Repo) removeUserFromRoom(ctx context.Context, userID, roomID int64) err
 
 func (r *Repo) getUserRooms(ctx context.Context, userID int64) ([]string, error) {
 	rows, err := r.pool.Query(ctx, `
-        select ro.name from rooms ro
+        select distinct ro.name from rooms ro
         join room_members rm on rm.room_id = ro.id
         where rm.user_id = $1
         order by ro.name
@@ -278,6 +278,7 @@ func (r *Repo) getUserRooms(ctx context.Context, userID int64) ([]string, error)
 		return nil, err
 	}
 	defer rows.Close()
+	seen := make(map[string]bool)
 	var names []string
 	for rows.Next() {
 		var name string
@@ -286,7 +287,11 @@ func (r *Repo) getUserRooms(ctx context.Context, userID int64) ([]string, error)
 		if !strings.HasPrefix(name, "dm:") && !strings.HasPrefix(name, "#") {
 			name = "#" + name
 		}
-		names = append(names, name)
+		// Skip duplicates (belt-and-suspenders deduplication)
+		if !seen[name] {
+			names = append(names, name)
+			seen[name] = true
+		}
 	}
 	fmt.Printf("✓ getUserRooms: userID=%d, found %d rooms: %v\n", userID, len(names), names)
 	return names, nil


### PR DESCRIPTION
Implement automatic gain control for voice capture and improve room/voice-channel handling.

- voice: add AGC fields, math import, calculateRMS and applyAGC (smoothing, gain clamping, clipping prevention) and invoke AGC in captureMic; lower VAD threshold to 0.25. Initialize agcTargetLevel and agcCurrentGain.
- chat: clear voiceChannels when leaving rooms; deduplicate rooms received from server and preserve existing room.voiceChannels when rebuilding roomsWithVoice.
- store: use DISTINCT in getUserRooms query and guard against duplicate names in returned list.

These changes normalize microphone levels for more consistent audio and avoid duplicate/losing voice-channel state when room lists are refreshed.