### PR TITLE
Add presence notifications and update members UI

### DIFF
--- a/cmd/app/chat.go
+++ b/cmd/app/chat.go
@@ -107,7 +107,7 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 	var currentRoom string
 	var currentDMKey []byte
 	var isDM bool
-	var members []string
+	var members []FriendStatus
 	var roomsWithVoice []RoomWithVoice
 	var voiceClient *VoiceClient
 	var voiceMembers []VoiceMember
@@ -178,9 +178,21 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 	// -- MEMBERS PANEL --
 	membersList := widget.NewList(
 		func() int { return len(members) },
-		func() fyne.CanvasObject { return widget.NewLabel("") },
+		func() fyne.CanvasObject {
+			dot := widget.NewLabel("●")
+			name := widget.NewLabel("")
+			return container.NewHBox(dot, name)
+		},
 		func(i widget.ListItemID, o fyne.CanvasObject) {
-			o.(*widget.Label).SetText("● " + members[i])
+			row := o.(*fyne.Container)
+			dot := row.Objects[0].(*widget.Label)
+			name := row.Objects[1].(*widget.Label)
+			name.SetText(members[i].nick)
+			if members[i].online {
+				dot.SetText("●")
+			} else {
+				dot.SetText("○")
+			}
 		},
 	)
 
@@ -202,7 +214,7 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 		currentDMKey = deriveKey(myNick, targetNick)
 		isDM = true
 		msgs = []string{}
-		members = []string{}
+		members = []FriendStatus{}
 		membersList.Refresh()
 		msgView.Segments = nil
 		msgView.Refresh()
@@ -320,7 +332,7 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 	leaveBtn := widget.NewButton("🚪 Leave Room", func() {
 		conn.send("/leave")
 		msgs = []string{}
-		members = []string{}
+		members = []FriendStatus{}
 		membersList.Refresh()
 		msgView.Segments = nil
 		msgView.Refresh()
@@ -434,7 +446,7 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 			currentRoom = r.name
 			isDM = false
 			currentDMKey = nil
-			members = []string{}
+			members = []FriendStatus{}
 			membersList.Refresh()
 
 			// Clear all voice channels (we'll fetch new ones for current room only)
@@ -568,7 +580,7 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 	friendsBtn := widget.NewButton("👥 Friends", func() {
 		isDM = false
 		currentDMKey = nil
-		members = []string{}
+		members = []FriendStatus{}
 		membersList.Refresh()
 		roomsList.UnselectAll()
 		leaveBtn.Hide()
@@ -703,13 +715,53 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 				}
 				if strings.HasPrefix(msg, "** members: ") {
 					raw := strings.TrimPrefix(msg, "** members: ")
-					members = strings.Split(raw, ", ")
+					nicks := strings.Split(raw, ", ")
+					members = make([]FriendStatus, len(nicks))
+					for i, nick := range nicks {
+						members[i] = FriendStatus{nick: nick, online: false}
+					}
 					membersList.Refresh()
+					return
+				}
+				if strings.HasPrefix(msg, "** online: ") {
+					raw := strings.TrimPrefix(msg, "** online: ")
+					onlineSet := make(map[string]bool)
+					for _, nick := range strings.Split(raw, ", ") {
+						onlineSet[nick] = true
+					}
+					for i, m := range members {
+						members[i].online = onlineSet[m.nick]
+					}
+					membersList.Refresh()
+					return
+				}
+				if strings.HasPrefix(msg, "** presence: ") {
+					parts := strings.Fields(strings.TrimPrefix(msg, "** presence: "))
+					if len(parts) == 2 {
+						nick, status := parts[0], parts[1]
+						for i, m := range members {
+							if m.nick == nick {
+								members[i].online = status == "online"
+								break
+							}
+						}
+						membersList.Refresh()
+					}
 					return
 				}
 				if strings.HasPrefix(msg, "** joined: ") {
 					nick := strings.TrimPrefix(msg, "** joined: ")
-					members = append(members, nick)
+					found := false
+					for i, m := range members {
+						if m.nick == nick {
+							members[i].online = true
+							found = true
+							break
+						}
+					}
+					if !found {
+						members = append(members, FriendStatus{nick: nick, online: true})
+					}
 					membersList.Refresh()
 					return
 				}
@@ -719,8 +771,8 @@ func chatScreen(w fyne.Window, conn *Connection, myNick string, serverAddr strin
 				if strings.HasPrefix(msg, "** left: ") {
 					nick := strings.TrimPrefix(msg, "** left: ")
 					for i, m := range members {
-						if m == nick {
-							members = append(members[:i], members[i+1:]...)
+						if m.nick == nick {
+							members[i].online = false
 							break
 						}
 					}

--- a/cmd/server/client.go
+++ b/cmd/server/client.go
@@ -39,6 +39,7 @@ func (s *Server) acceptLoop(ctx context.Context) {
 func (s *Server) readLoop(c *Client) {
 	defer func() {
 		s.notifyFriendsOffline(c)
+		s.notifyRoomMembersPresence(c, "offline")
 		s.unregisterClientSingle(c)
 		if c.activeRoom != nil {
 			c.activeRoom.mu.Lock()

--- a/cmd/server/commands.go
+++ b/cmd/server/commands.go
@@ -179,6 +179,7 @@ func (s *Server) handleCommand(c *Client, cmd string, r *bufio.Reader) {
 		s.sendLine(c, "** welcome, %s!", retNick)
 		s.registerClientSingle(c)
 		s.notifyFriendsOnline(c)
+		s.notifyRoomMembersPresence(c, "online")
 
 		// Ensure #main room exists in database with correct ID
 		mainID, mainName, err := s.repo.UpsertRoomByName(context.Background(), "#main", id)

--- a/cmd/server/room.go
+++ b/cmd/server/room.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -81,9 +82,26 @@ func (s *Server) joinRoom(c *Client, r *Room) {
 	r.mu.Unlock()
 	c.activeRoom = r
 
-	// send current members to joining client
-	nicks := r.memberNicks()
-	s.sendLine(c, "** members: %s", strings.Join(nicks, ", "))
+	// Send all users who have access to this room (from DB)
+	allMembers, err := s.repo.getRoomMembers(context.Background(), r.ID)
+	if err != nil || len(allMembers) == 0 {
+		// Fallback: just send currently connected nicks
+		nicks := r.memberNicks()
+		s.sendLine(c, "** members: %s", strings.Join(nicks, ", "))
+	} else {
+		s.sendLine(c, "** members: %s", strings.Join(allMembers, ", "))
+		// Tell client which of those are currently online (connected to server)
+		onlineSet := s.connectedNicksSet()
+		var onlineNicks []string
+		for _, nick := range allMembers {
+			if onlineSet[nick] {
+				onlineNicks = append(onlineNicks, nick)
+			}
+		}
+		if len(onlineNicks) > 0 {
+			s.sendLine(c, "** online: %s", strings.Join(onlineNicks, ", "))
+		}
+	}
 
 	s.sendLine(c, "** joined %s", r.Name)
 }
@@ -96,4 +114,24 @@ func (r *Room) memberNicks() []string {
 		nicks = append(nicks, c.nick)
 	}
 	return nicks
+}
+
+func (r *Room) memberNicksSet() map[string]bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	set := make(map[string]bool, len(r.clients))
+	for c := range r.clients {
+		set[c.nick] = true
+	}
+	return set
+}
+
+func (s *Server) connectedNicksSet() map[string]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	set := make(map[string]bool, len(s.clientsByUser))
+	for _, c := range s.clientsByUser {
+		set[c.nick] = true
+	}
+	return set
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -87,6 +87,31 @@ func (s *Server) notifyFriendsOffline(c *Client) {
 	}
 }
 
+// notifyRoomMembersPresence broadcasts a presence update to all clients currently
+// occupying any room that c has access to (excluding c itself).
+func (s *Server) notifyRoomMembersPresence(c *Client, status string) {
+	ctx := context.Background()
+	roomNames, err := s.repo.getUserRooms(ctx, c.UserID)
+	if err != nil {
+		return
+	}
+	for _, roomName := range roomNames {
+		s.mu.RLock()
+		r, ok := s.rooms[roomName]
+		s.mu.RUnlock()
+		if !ok {
+			continue
+		}
+		r.mu.RLock()
+		for roomClient := range r.clients {
+			if roomClient != c {
+				s.sendLine(roomClient, "** presence: %s %s", c.nick, status)
+			}
+		}
+		r.mu.RUnlock()
+	}
+}
+
 func (s *Server) broadcastToRoom(r *Room, msg string) {
 	if r == nil {
 		return


### PR DESCRIPTION
Introduce presence tracking between server and client: server now notifies room members when a user goes online/offline (notifyRoomMembersPresence) and sends room membership from the DB plus a separate ** online: list on join. joinRoom falls back to connected clients when DB lookup fails. New helper methods (memberNicksSet, connectedNicksSet) were added to support presence checks. Client UI switched members from []string to []FriendStatus, renders a presence dot in the member list, and handles new server messages (** online:, ** presence:) to update per-user online status; join/left handling was adjusted to update presence instead of simply adding/removing strings. Also trigger presence notifications on client register and read-loop exit.